### PR TITLE
region property for S3 is no longer supported

### DIFF
--- a/AWS/main.tf
+++ b/AWS/main.tf
@@ -7,7 +7,6 @@ terraform {
   required_version = ">= 0.12"
   backend "s3" {
     bucket         = "{BUCKET}"
-    region         = "{REGION}"
     profile        = "{PROFILE}"
 
     key            = "aws.tfstate"


### PR DESCRIPTION
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-3-upgrade#region-attribute-is-now-read-only